### PR TITLE
Use base_class to use register audits as their parent class

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -181,7 +181,7 @@ module Audited
       def own_and_associated_audits
         Audited.audit_class.unscoped
         .where('(auditable_type = :type AND auditable_id = :id) OR (associated_type = :type AND associated_id = :id)',
-          type: self.class.name, id: id)
+          type: self.class.base_class.name, id: id)
         .order(created_at: :desc)
       end
 


### PR DESCRIPTION
Fix audit creation and reading of classes using their parent audits (such as professional models, organization medical case, profile, etc)